### PR TITLE
refactor: rename config variables to follow GitLab's patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ urlpatterns = [
 
 ```python
 GITLAB_PROJECT_ID = 123456
-GITLAB_PRIVATE_TOKEN = "your-token-here"
-GITLAB_URL = "https://gitlab.com"
+GITLAB_TOKEN = "your-token-here"
+GITLAB_HOST = "https://gitlab.com"
 ```
 
 ### Visit your release page 

--- a/gitlab_releases/client.py
+++ b/gitlab_releases/client.py
@@ -17,8 +17,8 @@ class Gitlab:
         pagination: Optional[str] = None,
         order_by: Optional[str] = None,
     ):
-        url = url or settings.GITLAB_URL
-        private_token = private_token or settings.GITLAB_PRIVATE_TOKEN
+        url = url or settings.GITLAB_HOST
+        private_token = private_token or settings.GITLAB_TOKEN
         api_version = api_version or settings.GITLAB_API_VERSION
         timeout = timeout or settings.GITLAB_TIMEOUT
         per_page = per_page or settings.GITLAB_PER_PAGE

--- a/gitlab_releases/conf.py
+++ b/gitlab_releases/conf.py
@@ -2,8 +2,8 @@ from django.conf import settings
 
 GITLAB_RELEASES = {
     "GITLAB_PROJECT_ID": None,
-    "GITLAB_PRIVATE_TOKEN": None,
-    "GITLAB_URL": "https://gitlab.com",
+    "GITLAB_TOKEN": None,
+    "GITLAB_HOST": "https://gitlab.com",
     "GITLAB_API_VERSION": "4",
     "GITLAB_TIMEOUT": 5.0,  # seconds
     "GITLAB_PER_PAGE": 10,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gitlab-releases"
-version = "0.1.0"
+version = "0.2.0"
 description = "Gitlab Releases for Django projects"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -12,8 +12,8 @@ class GitlabTestCase(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.settings_patch = override_settings(
-            GITLAB_URL=cls.gitlab_url,
-            GITLAB_PRIVATE_TOKEN="fake-token",
+            GITLAB_HOST=cls.gitlab_url,
+            GITLAB_TOKEN="fake-token",
             GITLAB_API_VERSION="4",
             GITLAB_TIMEOUT=10,
             GITLAB_PER_PAGE=10,


### PR DESCRIPTION
The following config variables were changed:

- GITLAB_PRIVATE_TOKEN to GITLAB_TOKEN
- GITLAB_URL to GITLAB_HOST

Refs: #8